### PR TITLE
fix error-throwing after 'request-promise-native' was replaced with 'node-fetch'

### DIFF
--- a/fetch-bitsy-source.mjs
+++ b/fetch-bitsy-source.mjs
@@ -14,7 +14,7 @@ async function fetchFile(url, savePath) {
 	try {
 		response = await fetch(url);
 	} catch (err) {
-		throw new Error(`${url} is not available\n${err.error}`);
+		throw new Error(`${url} is not available\n${err}`);
 	}
 
 	if (response.ok) {


### PR DESCRIPTION
little fix.. request-promise-native had some quirky structure for errors and i had to use `error.error` to get the actual error message to throw something helpful instead of a ginormous object with lots of stuff