### PR TITLE
add node 14.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "watch-html": "npm-watch build-html",
     "build": "npm run build-hacks&&npm run build-html",
     "start": "concurrently 'npm:watch-*'",
-    "fetch-bitsy": "node --experimental-modules fetch-bitsy-source.mjs",
+    "fetch-bitsy": "node --experimental-modules --experimental-json-modules fetch-bitsy-source.mjs",
     "postinstall": "npm run fetch-bitsy"
   },
   "author": "Sean S. LeBlanc & Elkie Nova",


### PR DESCRIPTION
importing json as es6 modules requires another flag now

fixes #4 