### PR TITLE
add import assertion

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -4,7 +4,7 @@ import optimize from '@bitsy/optimizer';
 import optimizeOptions from './input/optimization';
 import resolve from 'resolve';
 import externalDeps from './external-deps';
-import bitsyPaths from './bitsy-paths.json';
+import bitsyPaths from './bitsy-paths.json' assert { type: "json" };
 
 const fontName = 'ascii_small';
 


### PR DESCRIPTION
`index.mjs` need import assertion too, else `npm run build` throw error
```
> bitsy-boilerplate@1.0.0 build-html
> node --experimental-modules --es-module-specifier-resolution=node index.mjs

node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

TypeError [ERR_IMPORT_ASSERTION_TYPE_MISSING]: Module "file:///D:/mypath/bitsy-boilerplate-tower/bitsy-paths.json" needs an import assertion of type "json"
    at new NodeError (node:internal/errors:371:5)
    at validateAssertions (node:internal/modules/esm/assert:82:15)
    at defaultLoad (node:internal/modules/esm/load:24:3)
    at ESMLoader.load (node:internal/modules/esm/loader:359:26)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:280:58)
    at new ModuleJob (node:internal/modules/esm/module_job:66:26)
    at ESMLoader.#createModuleJob (node:internal/modules/esm/loader:297:17)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:261:34)
    at async ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:81:21)
    at async Promise.all (index 6) {
  code: 'ERR_IMPORT_ASSERTION_TYPE_MISSING'
}

Node.js v17.5.0
```